### PR TITLE
Update the repo versions for OTP 16 version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-    {color, ".*", {git, "git://github.com/basho/erlang-color.git"}},
-    {tdiff, ".*", {git, "git://github.com/basho/tdiff.git"}}
+    {color, ".*", {git, "https://github.com/basho/erlang-color.git", {tag, "v0.2.0p1"}}},
+    {tdiff, ".*", {git, "https://github.com/basho/tdiff.git", {tag, "0.1"}}}
 ]}.


### PR DESCRIPTION
Looks like the OTP 18 version breaks the current build, so simply update the deps 